### PR TITLE
Fix NRFilter for scipy>=1.14.0

### DIFF
--- a/NR_signal_generator/__init__.py
+++ b/NR_signal_generator/__init__.py
@@ -1320,7 +1320,7 @@ class NR_signal_generator(thesdk): #rtl,eldo,thesdk
         for sb_max in sb_max_list:
             for ord in range(N_min,N_max):
                 try:
-                    b=sig.remez(int(ord+1),[0,Fc-dF,att_freq,0.5*Fs],[1,0],Hz=int(Fs)) 
+                    b=sig.remez(int(ord+1),[0,Fc-dF,att_freq,0.5*Fs],[1,0],fs=int(Fs))
                     #order=ord
                     #plt.figure()
                     #plt.plot(b)
@@ -1334,9 +1334,8 @@ class NR_signal_generator(thesdk): #rtl,eldo,thesdk
                         order=ord
                         self.fil_len=ord
                         break
-                   
-                except:
-                    pass
+                except Exception as e:
+                    self.print_log(type='W', msg=f"{e}")
             else:
                 continue
             break


### PR DESCRIPTION
The `Hz` parameter in remez has been deprecated since scipy version 1.0, and was finally removed in 1.14.0. Replace it with `fs`. Should still work with older scipy versions.

Also, print out warnings instead of silently eating up Exceptions caused by failing method calls.

Fixes #1 